### PR TITLE
修复 Android U 无法获取 SharedPreferences

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,7 +106,8 @@
             android:name=".provider.SharedPrefsProvider"
             android:authorities="com.sevtinge.cemiuiler.provider.sharedprefs"
             android:directBootAware="true"
-            android:exported="false"
+            android:exported="true"
+            android:defaultToDeviceProtectedStorage="true"
             android:grantUriPermissions="true" />
 
         <meta-data

--- a/app/src/main/java/com/sevtinge/cemiuiler/Application.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/Application.java
@@ -1,6 +1,8 @@
 package com.sevtinge.cemiuiler;
 
 import android.content.Context;
+import android.os.Build;
+import android.util.Log;
 
 import com.sevtinge.cemiuiler.utils.PrefsUtils;
 
@@ -8,7 +10,7 @@ public class Application extends android.app.Application {
 
     @Override
     protected void attachBaseContext(Context base) {
-        PrefsUtils.mSharedPreferences = PrefsUtils.getSharedPrefs(base, false);
+        PrefsUtils.mSharedPreferences = PrefsUtils.getSharedPrefs(base, Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
         super.attachBaseContext(base);
     }
 


### PR DESCRIPTION
Fix:
Cemiuiler: [UID xxx] Cannot read module's SharedPreferences, some mods might not work!

Tested On: Mi 13 Pro (Xiaomi/nuwa/nuwa:14/UKQ1.230705.002/V14.0.0.4.UMBCNXM:user/release-keys)