### PR TITLE
修复 ALPermissionManager 没有被 import

### DIFF
--- a/app/src/main/java/com/sevtinge/cemiuiler/view/RestartAlertDialog.java
+++ b/app/src/main/java/com/sevtinge/cemiuiler/view/RestartAlertDialog.java
@@ -6,6 +6,7 @@ import android.content.res.Resources;
 
 import com.sevtinge.cemiuiler.R;
 import com.sevtinge.cemiuiler.module.GlobalActions;
+import com.sevtinge.cemiuiler.utils.ALPermissionManager;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
It's a shame for me.
忘记导入 ALPermissionManager 包导致了 CI boom，没有下次了.